### PR TITLE
adding exception handling for days exceeding life of stock

### DIFF
--- a/src/functions.py
+++ b/src/functions.py
@@ -218,12 +218,16 @@ def getHistoricalData(ticker, region, days):
     response = requests.request("GET", url, headers=headers, params=querystring)
     # Transform the data into json so we can fetch the data we need easily.
     data = response.json()
+
+    if len(data['prices']) < int(days):
+        raise Exception("Invalid Entry. The stock may not have data available for this time period. Please try again.")
+    
     # We get the data from prices on the given amount of days wanted from historical data
     historicalData = data['prices'][int(days)]
 
     # If the fetched results are empty, that means the data has to be invalid.
     if len(historicalData) == 0:
-        raise Exception("Invalid Entry, please try again.")
+        raise Exception("Invalid Entry. The stock may not have data available for this time period. Please try again.")
 
     current_data = get_live_price(ticker)
 

--- a/stockbot.py
+++ b/stockbot.py
@@ -96,7 +96,12 @@ async def live(ctx, arg1, *args):
 async def hist(ctx, arg1, *args):
     if args[0].isdigit():
         # No region specified, default to US
-        stockResult = getHistoricalData(arg1, 'US', args[0])
+        try:
+            stockResult = getHistoricalData(arg1, 'US', args[0])
+        except Exception as e:
+            await ctx.send(embed = Embedder.error(str(e)))
+            return
+
         marker = '' if stockResult['PriceChange'] < 0 else '+'
         currency, pricediff, percentdiff = stockResult['Currency'], \
                                            stockResult['PriceChange'], stockResult['PriceChangePercentage']
@@ -108,7 +113,12 @@ async def hist(ctx, arg1, *args):
     else:
         # Region is specified, so there should be 2 arguments: region and number of days
         suffix = findSuffix(arg1)[1]
-        stockResult = getHistoricalData(arg1, args[0].upper(), args[1])
+        try:
+            stockResult = getHistoricalData(arg1, args[0].upper(), args[1])
+        except Exception as e:
+            await ctx.send(embed = Embedder.error(str(e)))
+            return
+        
         marker = '' if stockResult['PriceChange'] < 0 else '+'
         currency, pricediff, percentdiff = stockResult['Currency'], stockResult['PriceChange'], stockResult[
             'PriceChangePercentage']


### PR DESCRIPTION
if a stock is newer (i.e. BTCC-B.TO) doing !live command with a day larger than its lifespan should return a proper error message. 
This is now handled and returns a formatted message appropriately.